### PR TITLE
Bump version

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "rack"
-  s.version         = "1.6.13"
+  s.version         = "1.6.14"
   s.platform        = Gem::Platform::RUBY
   s.summary         = "a modular Ruby webserver interface"
   s.license         = "MIT"


### PR DESCRIPTION
Bump version to indicate this includes a fix for CVE-2020-8161

Bumping the version allows automated security checkers to confirm the gem has been patched