### PR TITLE
Disallow percent-encoded cookies to overwrite existing prefixed cooki…

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -11,10 +11,10 @@ which all Rack applications should conform to.
 
 == LTS version
 
-This is a fork of the official {rack gem}[https://github.com/rack/rack] with backportet security fixes for:
+This is a fork of the official {rack gem}[https://github.com/rack/rack] with backported security fixes for:
 
-* {rack 1.6}[https://github.com/rails-lts/rack/tree/lts-1-6-stable] (CVE-2020-8161)
-* {rack 1.4}[https://github.com/rails-lts/rack/tree/lts-rack-1.4] (CVE-2018-16471, CVE-2020-8161)
+* {rack 1.6}[https://github.com/rails-lts/rack/tree/lts-1-6-stable] (CVE-2020-8161, CVE-2020-8184)
+* {rack 1.4}[https://github.com/rails-lts/rack/tree/lts-rack-1.4] (CVE-2018-16471, CVE-2020-8161, CVE-2020-8184)
 
 To use it, you need to add it to the Gemfile like this:
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -260,8 +260,15 @@ module Rack
       #   the Cookie header such that those with more specific Path attributes
       #   precede those with less specific.  Ordering with respect to other
       #   attributes (e.g., Domain) is unspecified.
-      cookies = Utils.parse_query(string, ';,') { |s| Rack::Utils.unescape(s) rescue s }
-      cookies.each { |k,v| hash[k] = Array === v ? v.first : v }
+      (string || '').split(/[;,] */n).each do |cookie|
+        unless cookie.empty?
+          key, value = cookie.split('=', 2)
+          value = (Rack::Utils.unescape(value) rescue value)
+
+          hash[key] = value unless hash.key?(key)
+        end
+      end
+
       @env["rack.request.cookie_string"] = string
       hash
     end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -440,6 +440,26 @@ describe Rack::Request do
     })
   end
 
+  # This has changed in newer Rack versions (sanity check for backports)
+  should "ignore empty cookie pairs" do
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=bar;;quux=h&m")
+    req.cookies.should.equal "foo" => "bar", "quux" => "h&m"
+  end
+
+  # This has changed in newer Rack versions (sanity check for backports)
+  should "support a comma as cookie separator" do
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=bar,quux=h&m")
+    req.cookies.should.equal "foo" => "bar", "quux" => "h&m"
+  end
+
+  should "disallow percent-encoded cookies to overwrite existing prefixed cookie names" do
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("", "HTTP_COOKIE" => "%66oo=baz;foo=bar")
+    req.cookies.should.equal "%66oo" => "baz", "foo" => "bar"
+  end
+
   should "provide setters" do
     req = Rack::Request.new(e=Rack::MockRequest.env_for(""))
     req.script_name.should.equal ""


### PR DESCRIPTION
…e names (CVE-2020-8184)

Backport for https://groups.google.com/forum/#!topic/rubyonrails-security/OWtmozPH9Ak.